### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,8 @@
 name: Build and Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master, dev, 'f#*']


### PR DESCRIPTION
Potential fix for [https://github.com/renedierking/LANdalf/security/code-scanning/10](https://github.com/renedierking/LANdalf/security/code-scanning/10)

In general, the fix is to explicitly set a `permissions` block to restrict the `GITHUB_TOKEN` to the least privileges required. For a build-and-test workflow that only needs to read the repository contents and upload artifacts, `contents: read` is sufficient in most cases. Adding this at the workflow root will apply to all jobs unless overridden; adding it under a specific job will scope it just to that job.

For this workflow, the simplest and safest fix without changing existing behavior is to add a root-level `permissions` block with `contents: read`. None of the shown steps push commits, create releases, or interact with issues/PRs, so they do not need write permissions. Place the `permissions` block after the `name:` (line 1) and before `on:` (line 3), following GitHub Actions conventions. No imports or additional methods are needed because this is a YAML configuration-only change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
