### PR TITLE
Add ping utilities

### DIFF
--- a/src/API/Dockerfile
+++ b/src/API/Dockerfile
@@ -28,8 +28,9 @@ FROM base AS final
 WORKDIR /app
 
 # Install gosu for privilege de-escalation in the entrypoint
+# and iputils-ping for ICMP ping support in DeviceMonitoringService
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends gosu \
+    && apt-get install -y --no-install-recommends gosu iputils-ping \
     && rm -rf /var/lib/apt/lists/*
 
 # Create system user/group

--- a/src/API/Services/DeviceMonitoringService.cs
+++ b/src/API/Services/DeviceMonitoringService.cs
@@ -163,7 +163,13 @@ namespace API.Services {
         private async Task<bool> PingDeviceAsync(System.Net.IPAddress ipAddress, CancellationToken cancellationToken) {
             try {
                 using var ping = new Ping();
-                var reply = await ping.SendPingAsync(ipAddress, _options.TimeoutMilliseconds);
+                var reply = await ping.SendPingAsync(
+                    address: ipAddress,
+                    timeout: TimeSpan.FromMilliseconds(_options.TimeoutMilliseconds),
+                    buffer: null,
+                    options: null,
+                    cancellationToken: cancellationToken
+                );
                 return reply.Status == IPStatus.Success;
             } catch (PlatformNotSupportedException ex) {
                 _logger.LogError(ex, "Ping is not supported on this platform or runtime.");

--- a/src/API/Services/DeviceMonitoringService.cs
+++ b/src/API/Services/DeviceMonitoringService.cs
@@ -1,6 +1,4 @@
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
+﻿using Microsoft.Extensions.Options;
 using System.Net.NetworkInformation;
 using Microsoft.AspNetCore.SignalR;
 using API.Hubs;
@@ -167,6 +165,9 @@ namespace API.Services {
                 using var ping = new Ping();
                 var reply = await ping.SendPingAsync(ipAddress, _options.TimeoutMilliseconds);
                 return reply.Status == IPStatus.Success;
+            } catch (PlatformNotSupportedException ex) {
+                _logger.LogError(ex, "Ping is not supported on this platform. Install 'iputils-ping' or grant CAP_NET_RAW capability.");
+                return false;
             } catch (PingException ex) {
                 _logger.LogDebug(ex, "Ping failed for {IpAddress}", ipAddress);
                 return false;

--- a/src/API/Services/DeviceMonitoringService.cs
+++ b/src/API/Services/DeviceMonitoringService.cs
@@ -166,10 +166,10 @@ namespace API.Services {
                 var reply = await ping.SendPingAsync(ipAddress, _options.TimeoutMilliseconds);
                 return reply.Status == IPStatus.Success;
             } catch (PlatformNotSupportedException ex) {
-                _logger.LogError(ex, "Ping is not supported on this platform. Install 'iputils-ping' or grant CAP_NET_RAW capability.");
+                _logger.LogError(ex, "Ping is not supported on this platform or runtime.");
                 return false;
             } catch (PingException ex) {
-                _logger.LogDebug(ex, "Ping failed for {IpAddress}", ipAddress);
+                _logger.LogDebug(ex, "Ping failed for {IpAddress}. If running on Linux, ensure 'iputils-ping' is installed and the process has CAP_NET_RAW capability if required.", ipAddress);
                 return false;
             } catch (Exception ex) {
                 _logger.LogWarning(ex, "Unexpected error pinging {IpAddress}", ipAddress);

--- a/src/API/Services/DeviceMonitoringService.cs
+++ b/src/API/Services/DeviceMonitoringService.cs
@@ -11,6 +11,8 @@ namespace API.Services {
         private readonly DeviceMonitoringOptions _options;
         private readonly IHubContext<DeviceStatusHub> _hubContext;
 
+        private bool _platformNotSupportedLogged = false;
+
         public bool IsEnabled => _options.Enabled;
         public int IntervalSeconds => _options.IntervalSeconds;
         public int TimeoutMilliseconds => _options.TimeoutMilliseconds;
@@ -172,7 +174,10 @@ namespace API.Services {
                 );
                 return reply.Status == IPStatus.Success;
             } catch (PlatformNotSupportedException ex) {
-                _logger.LogError(ex, "Ping is not supported on this platform or runtime.");
+                if (!_platformNotSupportedLogged) {
+                    _platformNotSupportedLogged = true;
+                    _logger.LogWarning(ex, "Ping is not supported on this platform or runtime.");
+                }
                 return false;
             } catch (PingException ex) {
                 _logger.LogDebug(ex, "Ping failed for {IpAddress}. If running on Linux, ensure 'iputils-ping' is installed and the process has CAP_NET_RAW capability if required.", ipAddress);

--- a/src/API/Services/DeviceMonitoringService.cs
+++ b/src/API/Services/DeviceMonitoringService.cs
@@ -11,7 +11,7 @@ namespace API.Services {
         private readonly DeviceMonitoringOptions _options;
         private readonly IHubContext<DeviceStatusHub> _hubContext;
 
-        private bool _platformNotSupportedLogged = false;
+        private int _platformNotSupportedLogged = 0;
 
         public bool IsEnabled => _options.Enabled;
         public int IntervalSeconds => _options.IntervalSeconds;
@@ -174,8 +174,7 @@ namespace API.Services {
                 );
                 return reply.Status == IPStatus.Success;
             } catch (PlatformNotSupportedException ex) {
-                if (!_platformNotSupportedLogged) {
-                    _platformNotSupportedLogged = true;
+                if (Interlocked.CompareExchange(ref _platformNotSupportedLogged, 1, 0) == 0) {
                     _logger.LogWarning(ex, "Ping is not supported on this platform or runtime.");
                 }
                 return false;


### PR DESCRIPTION
This pull request enhances the `DeviceMonitoringService` by improving support for ICMP ping functionality, especially in containerized environments. The main changes ensure that the necessary system package is installed in the Docker image and that the service gracefully handles unsupported platform scenarios.

Dependency updates for ping support:

* Updated the Dockerfile (`src/API/Dockerfile`) to install `iputils-ping`, ensuring ICMP ping commands work inside the container.

Error handling improvements:

* Added a catch for `PlatformNotSupportedException` in `PingDeviceAsync` that logs a warning (at most once per service lifetime) when ping is not supported on the current platform. A thread-safe guard flag using `Interlocked.CompareExchange` prevents log spam when devices are checked in parallel.
* The `iputils-ping` / `CAP_NET_RAW` guidance is placed in the `PingException` catch path, where it is most relevant.

Code cleanup:

* Removed unused `using` directives from `DeviceMonitoringService.cs` for cleaner code.

## Summary

Describe what changed and why.

## How to Test

- [ ] `dotnet build LANdalf.slnx`
- [ ] `dotnet test`
- [ ] (If relevant) `docker compose up --build`

## Checklist

- [ ] No secrets/credentials committed
- [ ] Docs updated as needed (README/CONTRIBUTING)
- [ ] Tests added/updated for new behavior
- [ ] Breaking changes called out