### PR TITLE
chore(deps): update NuGet package references

### DIFF
--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -20,17 +20,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Asp.Versioning.Http" Version="8.1.1" />
-    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
+    <PackageReference Include="Asp.Versioning.Http" Version="10.0.0" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0" />
     <PackageReference Include="Cronos" Version="0.12.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.5">
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.13.20" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.14.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />

--- a/src/UI/UI.csproj
+++ b/src/UI/UI.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.*" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.*" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.*" />
     <PackageReference Include="MudBlazor" Version="9.3.0" />
   </ItemGroup>

--- a/test/API/API.Tests.csproj
+++ b/test/API/API.Tests.csproj
@@ -8,15 +8,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 


### PR DESCRIPTION
- src/API/API.csproj
- src/UI/UI.csproj
- test/API/API.Tests.csproj

## Summary
This pull request updates several NuGet package dependencies across the API, UI, and test projects to newer versions. These upgrades help keep the codebase current with the latest features, bug fixes, and security patches.

Dependency upgrades:

**API Project:**
* Upgraded `Asp.Versioning.Http` and `Asp.Versioning.Mvc.ApiExplorer` from version 8.1.1 to 10.0.0.
* Updated `Microsoft.AspNetCore.OpenApi`, `Microsoft.EntityFrameworkCore.Sqlite`, and `Microsoft.EntityFrameworkCore.Tools` from 10.0.5 to 10.0.7.
* Upgraded `Scalar.AspNetCore` from 2.13.20 to 2.14.2.

**UI Project:**
* Updated `Microsoft.AspNetCore.SignalR.Client` from 10.0.5 to 10.0.7.

**Test Project:**
* Upgraded `Microsoft.NET.Test.Sdk` from 18.3.0 to 18.4.0.
* Updated `Microsoft.EntityFrameworkCore.InMemory` and `Microsoft.AspNetCore.Mvc.Testing` from 10.0.5 to 10.0.7.

Describe what changed and why.

## How to Test

- [ ] `dotnet build LANdalf.slnx`
- [ ] `dotnet test`
- [ ] (If relevant) `docker compose up --build`

## Checklist

- [ ] No secrets/credentials committed
- [ ] Docs updated as needed (README/CONTRIBUTING)
- [ ] Tests added/updated for new behavior
- [ ] Breaking changes called out
